### PR TITLE
do not verify ssl on non-production env

### DIFF
--- a/lib/marketplace_kit/services/api_driver.rb
+++ b/lib/marketplace_kit/services/api_driver.rb
@@ -72,7 +72,9 @@ module MarketplaceKit
             'UserTemporaryToken' => MarketplaceKit.config.token,
             'Accept' => 'application/vnd.nearme.v4+json'
           }
-        }
+        }.tap do |config|
+          config[:ssl] = { verify: false } unless MarketplaceKit.config.endpoint == 'production'
+        end
       end
 
       def fix_font_file_encoding

--- a/lib/marketplace_kit/services/config.rb
+++ b/lib/marketplace_kit/services/config.rb
@@ -1,6 +1,10 @@
 module MarketplaceKit
   module Services
     class Config
+      def endpoint
+        @endpoint
+      end
+
       def load(endpoint_name)
         @config = {}
         @endpoint = endpoint_name


### PR DESCRIPTION
In dockerized version, staging uses self-signed certificates, and such certificates fail p2p verification. I would like to disable this verification on non-production envs.