### PR TITLE
DIY-145 test if platform

### DIFF
--- a/lib/marketplace_kit/services/user_authentication.rb
+++ b/lib/marketplace_kit/services/user_authentication.rb
@@ -1,3 +1,6 @@
+require 'base64'
+require 'uri'
+
 module MarketplaceKit
   module Services
     class UserAuthentication
@@ -6,7 +9,7 @@ module MarketplaceKit
       def authenticate
         return unless requires_login?
 
-        credentials = ask_for_email_and_password
+        credentials = parse_endpoint_url || ask_for_email_and_password
         login_and_remember credentials
       end
 
@@ -29,6 +32,13 @@ module MarketplaceKit
       def login_and_remember(credentials)
         user_token = gateway.login credentials[:email], credentials[:password]
         MarketplaceKit.config.set_token user_token
+      end
+
+      def parse_endpoint_url
+        userinfo        = URI(MarketplaceKit.config.url).userinfo || ''
+        email, password = Base64.urlsafe_decode64(userinfo).split(':')
+        return false if !email || !password
+        { email: email, password: password }
       end
 
       private


### PR DESCRIPTION
This PR adds possibility to pass email and password in HTTP basic auth way. For example, if email is `kacper@example.com` and password is `pass`, you need to 
- Encode it as you would do with the basic auth:
```ruby
string = 'kacper@example.com:pass'
Base64.urlsafe_encode64(string)
 => "a2FjcGVyQGV4YW1wbGUuY29tOnBhc3M="
```
- And then add this encoded string to an url in your `.builder` file:

```json
{
  "localhost": {
    "url": "https://a2FjcGVyQGV4YW1wbGUuY29tOnBhc3M=@lvh.me"
  }
}
```

Why add something like this?

Thanks to that user can login in a non-interactive way, which is now not possible (you need to enter an email manually).
This can be useful for automated tests of MP deployment. Right now it cannot be automated, since there is no non-interactive way to pass credentials.