### PR TITLE
PP-27 replace user temporary token with api key

### DIFF
--- a/lib/kit.js
+++ b/lib/kit.js
@@ -1,19 +1,25 @@
 const instance = process.env.NO_COLOR ? require('./logger/simple.js') : require('./logger/rainbow.js');
 
-const formatter = msg => {
-  const HHMMSS = new Date().toTimeString().split(' ')[0];
-  const message = typeof msg === 'string' ? msg : JSON.stringify(msg);
+const formatter = (msg, opts = {}) => {
+  const hideTimestamp = opts.hideTimestamp || false;
 
-  return `[${HHMMSS}] ${message}`;
+  let message = typeof msg === 'string' ? msg : JSON.stringify(msg);
+
+  if(!hideTimestamp) {
+    const HHMMSS = new Date().toTimeString().split(' ')[0];
+    message = `[${HHMMSS}] ${message}`;
+  }
+
+  return message;
 };
 
 const logger = {
-  Error: message => instance.Error(formatter(message)),
-  Success: message => instance.Success(formatter(message)),
-  Quiet: message => instance.Quiet(formatter(message)),
-  Info: message => instance.Info(formatter(message)),
-  Warn: message => instance.Warn(formatter(message)),
-  Print: message => instance.Print(message)
+  Error: (message, opts = {}) => instance.Error(formatter(message, opts)),
+  Success: (message, opts = {}) => instance.Success(formatter(message, opts)),
+  Quiet: (message, opts = {}) => instance.Quiet(formatter(message, opts)),
+  Info: (message, opts = {}) => instance.Info(formatter(message, opts)),
+  Warn: (message, opts = {}) => instance.Warn(formatter(message, opts)),
+  Print: (message, opts = {}) => instance.Print(message, opts)
 };
 
 module.exports = { logger };

--- a/lib/platformRequestHeaders.js
+++ b/lib/platformRequestHeaders.js
@@ -1,0 +1,9 @@
+const version = require('../package.json').version;
+
+module.exports = (opts) => (
+  {
+    "Authorization": `Token token=${opts.token}`,
+    "From": opts.email,
+    "User-Agent": `marketplace-kit/${version}`
+  }
+);

--- a/lib/platformRequestHeaders.js
+++ b/lib/platformRequestHeaders.js
@@ -2,8 +2,8 @@ const version = require('../package.json').version;
 
 module.exports = (opts) => (
   {
-    "Authorization": `Token token=${opts.token}`,
-    "From": opts.email,
-    "User-Agent": `marketplace-kit/${version}`
+    'Authorization': `Token token=${opts.token}`,
+    'From': opts.email,
+    'User-Agent': `marketplace-kit/${version}`
   }
 );

--- a/marketplace-kit-auth.js
+++ b/marketplace-kit-auth.js
@@ -25,6 +25,7 @@ const loadSettingsToEnv = environment => {
   const settings = existingSettings()[environment];
 
   if (settings) {
+    process.env['MARKETPLACE_EMAIL'] = settings.email;
     process.env['MARKETPLACE_TOKEN'] = settings.token;
     process.env['MARKETPLACE_URL'] = settings.url;
   } else {

--- a/marketplace-kit-deploy.js
+++ b/marketplace-kit-deploy.js
@@ -16,7 +16,7 @@ program
     process.env.CONFIG_FILE_PATH = params.configFile;
     if (params.force) process.env.FORCE = params.force;
     const authData = fetchAuthData(environment);
-    const env = Object.assign(process.env, { MARKETPLACE_TOKEN: authData.token, MARKETPLACE_URL: authData.url });
+    const env = Object.assign(process.env, { MARKETPLACE_EMAIL: authData.email, MARKETPLACE_TOKEN: authData.token, MARKETPLACE_URL: authData.url });
 
     // make an archive
     const archive = spawn(command('marketplace-kit-archive'), [], { stdio: 'inherit' });

--- a/marketplace-kit-env-add.js
+++ b/marketplace-kit-env-add.js
@@ -103,6 +103,7 @@ program
   .action((environment, params) => {
     process.env.CONFIG_FILE_PATH = params.configFile;
     checkParams(params);
+    logger.Info(`Please make sure that you have a permission to deploy. You can verify it here: ${partnerPortalHost()}/me/permissions`, {hideTimestamp: true});
     getPassword().then(password => {
       const settings = { url: params.url, endpoint: environment, email: params.email };
       login(params.email, password, settings);

--- a/marketplace-kit-logs.js
+++ b/marketplace-kit-logs.js
@@ -6,6 +6,7 @@ const program = require('commander'),
   request = require('request'),
   notifier = require('node-notifier'),
   logger = require('./lib/kit').logger,
+  platformRequestHeaders = require('./lib/platformRequestHeaders'),
   fs = require('fs');
 
 const fetchLogs = authData => {
@@ -15,7 +16,7 @@ const fetchLogs = authData => {
         uri: authData.url + 'api/marketplace_builder/logs',
         qs: { last_id: storage.lastId },
         method: 'GET',
-        headers: { UserTemporaryToken: authData.token }
+        headers: platformRequestHeaders({email: authData.email, token: authData.token})
       },
       (error, response, body) => {
         if (error) reject({ status: error });

--- a/marketplace-kit-push.js
+++ b/marketplace-kit-push.js
@@ -5,6 +5,7 @@ const program = require('commander'),
   fs = require('fs'),
   handleResponse = require('./lib/handleResponse'),
   logger = require('./lib/kit').logger,
+  platformRequestHeaders = require('./lib/platformRequestHeaders'),
   version = require('./package.json').version;
 
 const fetchDeploymentStatus = (id, authData) => {
@@ -13,7 +14,7 @@ const fetchDeploymentStatus = (id, authData) => {
       {
         uri: authData.url + 'api/marketplace_builder/marketplace_releases/' + id,
         method: 'GET',
-        headers: { UserTemporaryToken: authData.token }
+        headers: platformRequestHeaders({email: authData.email, token: authData.token})
       },
       (error, response, body) => {
         if (error) {
@@ -57,7 +58,7 @@ const pushFile = path => {
     {
       uri: program.url + 'api/marketplace_builder/marketplace_releases',
       method: 'POST',
-      headers: { UserTemporaryToken: program.token },
+      headers: platformRequestHeaders({email: program.email, token: program.token}),
       formData: formData
     },
     (error, response, body) => {
@@ -77,6 +78,7 @@ const pushFile = path => {
 
 program
   .version(version)
+  .option('--email <email>', 'developer email', process.env.MARKETPLACE_EMAIL)
   .option('--token <token>', 'authentication token', process.env.MARKETPLACE_TOKEN)
   .option('--url <url>', 'marketplace url', process.env.MARKETPLACE_URL)
   .option('-f --force', 'force update', process.env.FORCE); // not using force argument from parent process env

--- a/marketplace-kit-sync.js
+++ b/marketplace-kit-sync.js
@@ -15,6 +15,7 @@ program
     process.env.CONFIG_FILE_PATH = params.configFile;
     const authData = fetchAuthData(environment);
     const env = Object.assign(process.env, {
+      MARKETPLACE_EMAIL: authData.email,
       MARKETPLACE_TOKEN: authData.token,
       MARKETPLACE_URL: authData.url
     });

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -8,6 +8,7 @@ const program = require('commander'),
   watch = require('node-watch'),
   notifier = require('node-notifier'),
   logger = require('./lib/kit').logger,
+  platformRequestHeaders = require('./lib/platformRequestHeaders'),
   watchFilesExtensions = require('./lib/watch-files-extensions'),
   version = require('./package.json').version;
 
@@ -28,7 +29,7 @@ const ping = authData => {
       {
         uri: authData.url + 'api/marketplace_builder/logs',
         method: 'GET',
-        headers: { UserTemporaryToken: authData.token }
+        headers: platformRequestHeaders({email: authData.email, token: authData.token})
       },
       (error, response, body) => {
         if (error) reject({ status: error });
@@ -50,7 +51,7 @@ const pushFile = filePath => {
     {
       uri: program.url + 'api/marketplace_builder/marketplace_releases/sync',
       method: 'PUT',
-      headers: { UserTemporaryToken: program.token },
+      headers: platformRequestHeaders({email: program.email, token: program.token}),
       formData: {
         path: filePathUnixified(filePath), // need path with / separators
         marketplace_builder_file_body: fs.createReadStream(filePath)
@@ -73,6 +74,7 @@ const pushFile = filePath => {
 
 program
   .version(version)
+  .option('--email <email>', 'authentication token', process.env.MARKETPLACE_EMAIL)
   .option('--token <token>', 'authentication token', process.env.MARKETPLACE_TOKEN)
   .option('--url <url>', 'marketplace url', process.env.MARKETPLACE_URL)
   // .option('--files <files>', 'watch files', process.env.FILES || watchFilesExtensions)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@platform-os/marketplace-kit",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platform-os/marketplace-kit",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "Make changes in your marketplace on Platform OS",
   "main": "./marketplace-kit.js",
   "engines": {


### PR DESCRIPTION
TO DO before merge:

- [x] Bump version to `2.0.0`.
- [x] Update POS [PR](https://github.com/mdyd-dev/desksnearme/pull/7072) (should base on version less than 2.0.0 logic).
- [x] Add "Make sure you have permissions to deploy on portal.apps.near-me.com/me/permission.".info during authorization.
- [ ] ~~Add Invalidate Token button in PP.~~ Moved outside scope of this ticket.
- [ ] ~~Add deprecated warning when using old mp-kit.~~ Not possible - Old mp kit versions does not handle additional messages from the backend.
- [x] Update documentation.
- [x] Add link to documentation on PP sign in page, explaining how to get access to PP
- [x] Merge https://github.com/mdyd-dev/nearme-documentation/pull/107
- [x] Merge https://github.com/mdyd-dev/marketplace-kit/pull/65/files