### PR TITLE
Data migrations

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -121,25 +121,30 @@ class Gateway {
     });
   }
 
-  // runMigration(formData) {
-  //   logger.Debug('Generating Migration');
-  //   logger.Debug(formData);
+  runMigration(formData) {
+    logger.Info('Running Migration');
 
-  //   return new Promise((resolve, reject) => {
-  //     request(
-  //       {
-  //         method: 'POST',
-  //         url: this.url + 'api/marketplace_builder/migrations/run',
-  //         headers: this.headers,
-  //         formData: formData
-  //       },
-  //       (error, resp, body) => {
-  //         if (error || body != '{}') reject(error || body);
-  //         else resolve(body);
-  //       }
-  //     );
-  //   });
-  // }
+    return new Promise((resolve, reject) => {
+      request(
+        {
+          method: 'POST',
+          url: this.url + 'api/marketplace_builder/migrations/run',
+          headers: this.headers,
+          json: true,
+          formData: formData
+        },
+        (error, response, body) => {
+          if (error) reject({ status: error });
+          else if (response.statusCode != 200)
+            reject({
+              status: response.statusCode,
+              message: response.body.error
+            });
+          else resolve(body);
+        }
+      );
+    });
+  }
 
   sync(formData) {
     logger.Debug('SYNC headers:');

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -96,6 +96,51 @@ class Gateway {
     });
   }
 
+  generateMigration(formData) {
+    logger.Info('Generating Migration');
+
+    return new Promise((resolve, reject) => {
+      request(
+        {
+          method: 'POST',
+          url: this.url + 'api/marketplace_builder/migrations',
+          headers: this.headers,
+          json: true,
+          formData: formData
+        },
+        (error, response, body) => {
+          if (error) reject({ status: error });
+          else if (response.statusCode != 200)
+            reject({
+              status: response.statusCode,
+              message: response.statusMessage
+            });
+          else resolve(body);
+        }
+      );
+    });
+  }
+
+  // runMigration(formData) {
+  //   logger.Debug('Generating Migration');
+  //   logger.Debug(formData);
+
+  //   return new Promise((resolve, reject) => {
+  //     request(
+  //       {
+  //         method: 'POST',
+  //         url: this.url + 'api/marketplace_builder/migrations/run',
+  //         headers: this.headers,
+  //         formData: formData
+  //       },
+  //       (error, resp, body) => {
+  //         if (error || body != '{}') reject(error || body);
+  //         else resolve(body);
+  //       }
+  //     );
+  //   });
+  // }
+
   sync(formData) {
     logger.Debug('SYNC headers:');
     logger.Debug(this.headers);

--- a/marketplace-kit-migrations-generate.js
+++ b/marketplace-kit-migrations-generate.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
 const program = require('commander'),
-      Gateway = require('./lib/proxy'),
-      fs = require('fs'),
-      logger = require('./lib/kit').logger,
-      fetchAuthData = require('./lib/settings').fetchSettings,
-      version = require('./package.json').version;
+  Gateway = require('./lib/proxy'),
+  fs = require('fs'),
+  logger = require('./lib/kit').logger,
+  fetchAuthData = require('./lib/settings').fetchSettings,
+  version = require('./package.json').version;
 
 program
   .version(version)
@@ -21,16 +21,16 @@ program
 
     gateway.generateMigration(formData).then(
       body => {
-        logger.Success('[GenerateMigration] generated ${body["name"]}');
-        path = `${migrationsDir}/${body["name"]}.liquid`;
-
+        logger.Success(`[Migration - Generate] Done. ${body['name']} created`);
+        path = `${migrationsDir}/${body['name']}.liquid`;
         if (!fs.existsSync(migrationsDir)) {
           fs.mkdirSync(migrationsDir);
         }
-        fs.writeFileSync(path, body["body"], logger.Error);
+        fs.writeFileSync(path, body['body'], logger.Error);
+        logger.Success(`[Migration - Generate] Wrote an empty migration file to ${path}`);
       },
       error => {
-        logger.Error(`[GenerateMigration] ${error}`);
+        logger.Error(`[Migration - Generate] Error ${error.message}`);
       }
     );
   });

--- a/marketplace-kit-migrations-generate.js
+++ b/marketplace-kit-migrations-generate.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const program = require('commander'),
+      Gateway = require('./lib/proxy'),
+      fs = require('fs'),
+      logger = require('./lib/kit').logger,
+      fetchAuthData = require('./lib/settings').fetchSettings,
+      version = require('./package.json').version;
+
+program
+  .version(version)
+  .arguments('<environment>', 'name of the environment. Example: staging')
+  .arguments('<name>', 'base name of the migration. Example: cleanup_data')
+  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
+  .action((environment, name, params) => {
+    process.env.CONFIG_FILE_PATH = params.configFile;
+    const authData = fetchAuthData(environment);
+    const gateway = new Gateway(authData);
+    const formData = { 'name': name};
+    const migrationsDir = 'marketplace_builder/migrations';
+
+    gateway.generateMigration(formData).then(
+      body => {
+        logger.Success('[GenerateMigration] generated ${body["name"]}');
+        path = `${migrationsDir}/${body["name"]}.liquid`;
+
+        if (!fs.existsSync(migrationsDir)) {
+          fs.mkdirSync(migrationsDir);
+        }
+        fs.writeFileSync(path, body["body"], logger.Error);
+      },
+      error => {
+        logger.Error(`[GenerateMigration] ${error}`);
+      }
+    );
+  });
+
+program.parse(process.argv);

--- a/marketplace-kit-migrations-run.js
+++ b/marketplace-kit-migrations-run.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const program = require('commander'),
+  Gateway = require('./lib/proxy'),
+  logger = require('./lib/kit').logger,
+  fetchAuthData = require('./lib/settings').fetchSettings,
+  version = require('./package.json').version;
+
+program
+  .version(version)
+  .arguments('<environment>', 'name of the environment. Example: staging')
+  .arguments('<timestamp>', 'timestamp the migration. Example: 20180701182602')
+  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
+  .action((environment, timestamp, params) => {
+    process.env.CONFIG_FILE_PATH = params.configFile;
+    const authData = fetchAuthData(environment);
+    const gateway = new Gateway(authData);
+    const formData = { 'timestamp': timestamp };
+
+    gateway.runMigration(formData).then(
+      body => {
+        logger.Success(`[Migration - Run] Done. ${body['name']} executed.`);
+      },
+      error => {
+        logger.Error(`[Migration - Run] Error ${error.message}`);
+      }
+    );
+  });
+
+program.parse(process.argv);

--- a/marketplace-kit-migrations.js
+++ b/marketplace-kit-migrations.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const program = require('commander'),
+  logger = require('./lib/kit').logger,
+  version = require('./package.json').version;
+
+program
+  .version(version)
+  .command('generate <environment> <name>', 'generate new empty migration')
+  .command('run <environment> <name>', 'run migration on environment')
+  .parse(process.argv);

--- a/marketplace-kit.js
+++ b/marketplace-kit.js
@@ -19,6 +19,7 @@ program
   .command('env', 'manage environments')
   .command('sync <environment>', 'update environment on file change')
   .command('logs <environment>', 'attach to environment log streams')
+  .command('migrations', 'generate or run a migration')
   .command('init', 'initialize required directory structure')
   .command('gui', 'gui for content editor, graphql')
   .command('install', 'install module')


### PR DESCRIPTION
# Data migrations

Migrations can be used when you need to change the data or execute some piece of code outside of the regular application running cycle, for example when you want to seed data on each environment.

# Generating an empty migration

The first step for using a migration is generating it through `marketplace-kit migrations` command.

Example:

```sh
marketplace-kit migrations generate ENVIRONMENT MIGRATION_NAME
```

On success, this will generate an empty migration in `marketplace_builder/migrations` directory. 
Please notice that the name you provide will be prefixed with UTC timestamp, for example, looking like this: `20180731120002` this value is used to keep the migrations in order in all environments.


# Implementing migration

You can use the liquid markup in migration files - that includes executing GraphQL mutations (`execute_query` tag). 
Migration file can be synced many times but be careful about using deploys with migrations that are not 
ready - **deployment runs all migrations that are in pending status**.

# Running migration

As mentioned above deployment will try to run migrations one by one (in timestamp ordered fashion) and it will fail if one of the migrations fails.

There is also a command that runs a single migration:

```sh
marketplace-kit migrations run ENVIRONMENT MIGRATION_TIMESTAMP
```

**NOTICE** You have to provide the timestamp, not the full name, so for example: `20180731120002`

# Migration statuses

Newly created migration is in `pending` status for as long as it has not been run. Once it's executed (either 
through a `deploy` or using `migrations run`) it will progress to either `done` (on success) or `error` status.

Once migration is in `done` status it can't be run any more - this way it's safer to run the same queue of migrations on all environents in turn.

When an error occurs migration can still be edited and rerun untill it succeeds.

## Example

Here's a screenshot of creating and running a migration that logs a simple message:

![migrationsdemo](https://user-images.githubusercontent.com/25693/43462724-2ae83c8c-94d7-11e8-9204-68df7153be46.png)

