### PR TITLE
Add support for public and private folders

### DIFF
--- a/marketplace-kit-archive.js
+++ b/marketplace-kit-archive.js
@@ -17,14 +17,10 @@ const checkDirectory = directoryPath => {
 };
 
 const makeArchive = (path, directory) => {
-  //checkDirectory(directory);
-
   logger.Info(path);
 
   shell.mkdir('-p', 'tmp');
   shell.rm('-rf', path);
-
-
 
   const output = fs.createWriteStream(path);
   const archive = archiver('zip', { zlib: { level: 6 } });

--- a/marketplace-kit-archive.js
+++ b/marketplace-kit-archive.js
@@ -17,8 +17,6 @@ const checkDirectory = directoryPath => {
 };
 
 const makeArchive = (path, directory) => {
-  logger.Info(path);
-
   shell.mkdir('-p', 'tmp');
   shell.rm('-rf', path);
 

--- a/marketplace-kit-archive.js
+++ b/marketplace-kit-archive.js
@@ -17,10 +17,14 @@ const checkDirectory = directoryPath => {
 };
 
 const makeArchive = (path, directory) => {
-  checkDirectory(directory);
+  //checkDirectory(directory);
+
+  logger.Info(path);
 
   shell.mkdir('-p', 'tmp');
   shell.rm('-rf', path);
+
+
 
   const output = fs.createWriteStream(path);
   const archive = archiver('zip', { zlib: { level: 6 } });

--- a/marketplace-kit-archive.js
+++ b/marketplace-kit-archive.js
@@ -45,16 +45,13 @@ const makeArchive = (path, directory) => {
   // pipe archive data to the file
   archive.pipe(output);
 
-  // append files from a sub-directory, putting its contents at the root of archive
-  // This is the legacy option for marketplace_builder
-  archive.directory(directory, false);
-
-  // New folders at the top level
-  // - public # public files for the project
-  // - private # private files visble only by the creator/owner
-  // - modules # installed modules
+  // - marketplace_builder
+  archive.directory(directory, true);
+  // - public, public files for the project
   archive.directory('public', true);
+  // - private, private files visble only to the creator/owner
   archive.directory('private', true);
+  // - modules, installed modules
   archive.directory('modules', true);
 
   // finalize the archive (ie we are done appending files but streams have to finish yet)
@@ -68,5 +65,4 @@ program
   .option('--target <target>', 'path to archive', process.env.TARGET || './tmp/marketplace-release.zip')
   .parse(process.argv);
 
-//makeArchive(program.target, program.dir);
-makeArchive(program.target, ".");
+makeArchive(program.target, program.dir);

--- a/marketplace-kit-archive.js
+++ b/marketplace-kit-archive.js
@@ -46,7 +46,16 @@ const makeArchive = (path, directory) => {
   archive.pipe(output);
 
   // append files from a sub-directory, putting its contents at the root of archive
+  // This is the legacy option for marketplace_builder
   archive.directory(directory, false);
+
+  // New folders at the top level
+  // - public # public files for the project
+  // - private # private files visble only by the creator/owner
+  // - modules # installed modules
+  archive.directory('public', true);
+  archive.directory('private', true);
+  archive.directory('modules', true);
 
   // finalize the archive (ie we are done appending files but streams have to finish yet)
   // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
@@ -59,4 +68,5 @@ program
   .option('--target <target>', 'path to archive', process.env.TARGET || './tmp/marketplace-release.zip')
   .parse(process.argv);
 
-makeArchive(program.target, program.dir);
+//makeArchive(program.target, program.dir);
+makeArchive(program.target, ".");

--- a/marketplace-kit-deploy.js
+++ b/marketplace-kit-deploy.js
@@ -12,10 +12,12 @@ program
   .version(version)
   .arguments('<environment>', 'name of environment. Example: staging')
   .option('-f --force', 'force update. Removes instance-admin lock')
+  .option('-p --partial-deploy', 'Partial deployment, does not remove data from directories missing from the build')
   .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .action((environment, params) => {
     process.env.CONFIG_FILE_PATH = params.configFile;
     if (params.force) process.env.FORCE = params.force;
+    if (params.partialDeploy) process.env.PARTIAL_DEPLOY = params.partialDeploy;
     const authData = fetchAuthData(environment);
     const env = Object.assign(process.env, {
       MARKETPLACE_EMAIL: authData.email,

--- a/marketplace-kit-deploy.js
+++ b/marketplace-kit-deploy.js
@@ -29,6 +29,12 @@ program
     // make an archive
     const archive = spawn(command('marketplace-kit-archive'), [], { stdio: 'inherit' });
 
+    archive.on('error', err => {
+      logger.Error('Deploy failed.');
+      logger.Error(err);
+      process.exit(1);
+    });
+
     archive.on('close', code => {
       if (code === 1) {
         logger.Error('Deploy failed.');

--- a/marketplace-kit-push.js
+++ b/marketplace-kit-push.js
@@ -50,6 +50,7 @@ const gateway = new Gateway(program);
 
 const formData = {
   'marketplace_builder[force_mode]': process.env.FORCE || 'false',
+  'marketplace_builder[partial_deploy]': process.env.PARTIAL_DEPLOY || 'false',
   'marketplace_builder[zip_file]': fs.createReadStream('./tmp/marketplace-release.zip')
 };
 

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
 const program = require('commander'),
-  Gateway = require('./lib/proxy'),
-  fs = require('fs'),
-  path = require('path'),
-  watch = require('node-watch'),
-  notifier = require('node-notifier'),
-  logger = require('./lib/kit').logger,
-  validate = require('./lib/validators'),
-  watchFilesExtensions = require('./lib/watch-files-extensions'),
-  version = require('./package.json').version;
+      Gateway = require('./lib/proxy'),
+      fs = require('fs'),
+      path = require('path'),
+      watch = require('node-watch'),
+      notifier = require('node-notifier'),
+      logger = require('./lib/kit').logger,
+      validate = require('./lib/validators'),
+      watchFilesExtensions = require('./lib/watch-files-extensions'),
+      version = require('./package.json').version;
 
 const shouldBeSynced = (filePath, event) => {
   return fileUpdated(event) && extensionAllowed(ext(filePath)) && !isHiddenFile(filename(filePath));
@@ -69,7 +69,7 @@ program
   .option('--email <email>', 'authentication token', process.env.MARKETPLACE_EMAIL)
   .option('--token <token>', 'authentication token', process.env.MARKETPLACE_TOKEN)
   .option('--url <url>', 'marketplace url', process.env.MARKETPLACE_URL)
-  // .option('--files <files>', 'watch files', process.env.FILES || watchFilesExtensions)
+// .option('--files <files>', 'watch files', process.env.FILES || watchFilesExtensions)
   .parse(process.argv);
 
 checkParams(program);
@@ -85,21 +85,29 @@ gateway.ping().then(
       process.exit(1);
     }
 
-    watch('marketplace_builder', { recursive: true }, (event, file) => {
-      shouldBeSynced(file, event) && enqueue(file);
-    });
+    if (fs.existsSync('marketplace_builder')) {
+      watch('marketplace_builder', { recursive: true }, (event, file) => {
+        shouldBeSynced(file, event) && enqueue(file);
+      });
+    }
 
-    watch('public', { recursive: true }, (event, file) => {
-      shouldBeSynced(file, event) && enqueue(file);
-    });
+    if (fs.existsSync('public')) {
+      watch('public', { recursive: true }, (event, file) => {
+        shouldBeSynced(file, event) && enqueue(file);
+      });
+    }
 
-    watch('private', { recursive: true }, (event, file) => {
-      shouldBeSynced(file, event) && enqueue(file);
-    });
+    if (fs.existsSync('private')) {
+      watch('private', { recursive: true }, (event, file) => {
+        shouldBeSynced(file, event) && enqueue(file);
+      });
+    }
 
-    watch('modules', { recursive: true }, (event, file) => {
-      shouldBeSynced(file, event) && enqueue(file);
-    });
+    if (fs.existsSync('modules')) {
+      watch('modules', { recursive: true }, (event, file) => {
+        shouldBeSynced(file, event) && enqueue(file);
+      });
+    }
   },
   error => {
     logger.Error(error);

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -80,12 +80,24 @@ const gateway = new Gateway(program);
 
 gateway.ping().then(
   () => {
-    if (!fs.existsSync('marketplace_builder')) {
-      logger.Error("marketplace_builder directory doesn't exist - cannot start watching it");
+    if (!fs.existsSync('marketplace_builder') && !fs.existsSync('public') && !fs.existsSync('private')) {
+      logger.Error("marketplace_builder, public or private directory has to exist!");
       process.exit(1);
     }
 
     watch('marketplace_builder', { recursive: true }, (event, file) => {
+      shouldBeSynced(file, event) && enqueue(file);
+    });
+
+    watch('public', { recursive: true }, (event, file) => {
+      shouldBeSynced(file, event) && enqueue(file);
+    });
+
+    watch('private', { recursive: true }, (event, file) => {
+      shouldBeSynced(file, event) && enqueue(file);
+    });
+
+    watch('modules', { recursive: true }, (event, file) => {
       shouldBeSynced(file, event) && enqueue(file);
     });
   },

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -77,7 +77,7 @@ program
   .option('--email <email>', 'authentication token', process.env.MARKETPLACE_EMAIL)
   .option('--token <token>', 'authentication token', process.env.MARKETPLACE_TOKEN)
   .option('--url <url>', 'marketplace url', process.env.MARKETPLACE_URL)
-// .option('--files <files>', 'watch files', process.env.FILES || watchFilesExtensions)
+  // .option('--files <files>', 'watch files', process.env.FILES || watchFilesExtensions)
   .parse(process.argv);
 
 checkParams(program);
@@ -89,7 +89,7 @@ const gateway = new Gateway(program);
 gateway.ping().then(
   () => {
     if (!fs.existsSync('marketplace_builder') && !fs.existsSync('public') && !fs.existsSync('private')) {
-      logger.Error("marketplace_builder, public or private directory has to exist!");
+      logger.Error('marketplace_builder, public or private directory has to exist!');
       process.exit(1);
     }
 


### PR DESCRIPTION
Adds support for deploying/synchronizing public and private folders.

This will allow project structure to look the following way:

```sh
* marketplace_builder
* public
* private
* modules
  * admin_cms
    * public
  * bootstrap_styles
    * public
```

In the above example:

* `marketplace_builder` can be used as usual
* `public` can be used instead of `marketplace_builder` or by module creators in which case this is the place where they can put files visible to anyone using the plugin
* `private` those files will be visible only to module creator/owner they will get deployed to target instance by Partner Portal, but if a developer does a `marketplace-kit pull` he/she will only get `public` folder for the extension.
* `modules` this is where the installed extensions are placed in this example there are two `admin_cms` and `bootstrap_styles`

This PR also adds partial deployment, the difference between `-p` and a regular deploy is that backend will ignore missing folders - and it will not try to delete configuration that is not present in the build.