### PR TITLE
Remove support for toplevel public and private dirs

### DIFF
--- a/marketplace-kit-archive.js
+++ b/marketplace-kit-archive.js
@@ -7,7 +7,7 @@ const program = require('commander'),
   logger = require('./lib/logger'),
   version = require('./package.json').version;
 
-const ALLOWED_DIRECTORIES = ['marketplace_builder', 'public', 'private', 'modules'];
+const ALLOWED_DIRECTORIES = ['marketplace_builder', 'modules'];
 const availableDirectories = () => ALLOWED_DIRECTORIES.filter(fs.existsSync);
 const isEmpty = dir => shell.ls(dir).length == 0;
 
@@ -55,13 +55,9 @@ const makeArchive = (path, directory, withoutAssets) => {
     // For modules for now we go with the old aproach (not through S3) to avoid problems
     // with deep nesting
     archive.glob('**/*', { cwd: directory, ignore: ['assets/**'] }, { prefix: directory });
-    archive.glob('**/*', { cwd: 'public', ignore: ['assets/**'] }, { prefix: 'public' });
-    archive.glob('**/*', { cwd: 'private', ignore: ['assets/**'] }, { prefix: 'private' });
     archive.glob('**/*', { cwd: 'modules' }, { prefix: 'modules' });
   } else {
     archive.directory(directory, true);
-    archive.directory('public', true);
-    archive.directory('private', true);
     archive.directory('modules', true);
   }
 

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -96,14 +96,12 @@ checkParams(program);
 const gateway = new Gateway(program);
 
 gateway.ping().then(() => {
-  if (!fs.existsSync('marketplace_builder') && !fs.existsSync('public') && !fs.existsSync('private')) {
-    logger.Error('marketplace_builder, public or private directory has to exist!');
+  if (!fs.existsSync('marketplace_builder') && !fs.existsSync('modules')) {
+    logger.Error('marketplace_builder or modules directory has to exist!');
   }
 
   logger.Info(`Enabling sync mode to: ${program.url}`);
 
   watchDirectory('marketplace_builder');
-  watchDirectory('public');
-  watchDirectory('private');
   watchDirectory('modules');
 });


### PR DESCRIPTION
From now on we can only develop modules in the `/modules` directory. The separation to `public` and `private` folders inside `modules/modulename/` still works but top-level `public` and `private` are no longer allowed.

The reason for this change is that developing modules on top-level would require backend code to parse module and replace paths in includes of layouts correctly when the module was installed and this would be hard to do and error prone
