### PR TITLE
Change spinner to use stdout

### DIFF
--- a/marketplace-kit-push.js
+++ b/marketplace-kit-push.js
@@ -37,7 +37,7 @@ const duration = (t0, t1) => {
 
 const t0 = performance.now();
 
-const spinner = ora({ text: `Deploying to: ${program.url}`, spinner: 'bouncingBar' }).start();
+const spinner = ora({ text: `Deploying to: ${program.url}`, stream: process.stdout, spinner: 'bouncingBar' }).start();
 
 const gateway = new Gateway(program);
 


### PR DESCRIPTION
The default is `stderr`. It's explained [here](https://github.com/sindresorhus/ora/issues/85#issuecomment-410576130) that:

> The reason it's stderr is so that it will not interfere with normal output. Most other spinners use stderr too.

I find this wrong, and since I use some mkit instrumentation I'd like to be able to say if there is something on `stderr` it means something went wrong along the way.
