### PR TITLE
ignore module files irrelevant for pOS

### DIFF
--- a/marketplace-kit-archive.js
+++ b/marketplace-kit-archive.js
@@ -55,10 +55,12 @@ const makeArchive = (path, directory, withoutAssets) => {
     // For modules for now we go with the old aproach (not through S3) to avoid problems
     // with deep nesting
     archive.glob('**/*', { cwd: directory, ignore: ['assets/**'] }, { prefix: directory });
-    archive.glob('**/*', { cwd: 'modules' }, { prefix: 'modules' });
+    archive.glob('*/public/**/*', { cwd: 'modules/' }, { prefix: 'modules' });
+    archive.glob('*/private/**/*', { cwd: 'modules/' }, { prefix: 'modules' });
   } else {
     archive.directory(directory, true);
-    archive.directory('modules', true);
+    archive.glob('*/public/**/*', { cwd: 'modules/' }, { prefix: 'modules' });
+    archive.glob('*/private/**/*', { cwd: 'modules/' }, { prefix: 'modules' });
   }
 
   // finalize the archive (ie we are done appending files but streams have to finish yet)

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -53,8 +53,10 @@ const isNotEmptyYML = filePath => {
 // Mdule files outside public or private folders are not synced
 const isModuleFile = f => {
   let pathArray = f.split(path.sep);
-  if ( 'modules' != pathArray[0]) { return true }
-  return ["private", "public"].includes(pathArray[2]);
+  if ( 'modules' != pathArray[0]) {
+    return true;
+  }
+  return ['private', 'public'].includes(pathArray[2]);
 };
 
 CONCURRENCY = 3;

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -52,8 +52,8 @@ const isNotEmptyYML = filePath => {
 
 // Mdule files outside public or private folders are not synced
 const isModuleFile = f => {
-  return !/^modules\/([^\/]+)\/((?!(public|private)).)*(\/.*)*$/.test(f)
-}
+  return !/^modules\/([^\/]+)\/((?!(public|private)).)*(\/.*)*$/.test(f);
+};
 
 CONCURRENCY = 3;
 

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -52,7 +52,9 @@ const isNotEmptyYML = filePath => {
 
 // Mdule files outside public or private folders are not synced
 const isModuleFile = f => {
-  return !/^modules\/([^\/]+)\/((?!(public|private)).)*(\/.*)*$/.test(f);
+  let pathArray = f.split(path.sep);
+  if ( 'modules' != pathArray[0]) { return true }
+  return ["private", "public"].includes(pathArray[2]);
 };
 
 CONCURRENCY = 3;

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -18,7 +18,8 @@ const filename = filePath => filePath.split(path.sep).pop();
 const filePathUnixified = filePath => filePath.replace(/\\/g, '/').replace('marketplace_builder/', '');
 const isEmpty = filePath => fs.readFileSync(filePath).toString().trim().length === 0;
 const shouldBeSynced = (filePath, event) => {
-  return fileUpdated(event) && extensionAllowed(filePath) && isNotHidden(filePath) && isNotEmptyYML(filePath);
+  return fileUpdated(event) && extensionAllowed(filePath) && isNotHidden(filePath) &&
+    isNotEmptyYML(filePath) && isModuleFile(filePath);
 };
 
 const fileUpdated = event => event === 'update';
@@ -48,6 +49,11 @@ const isNotEmptyYML = filePath => {
 
   return true;
 };
+
+// Mdule files outside public or private folders are not synced
+const isModuleFile = f => {
+  return !/^modules\/([^\/]+)\/((?!(public|private)).)*(\/.*)*$/.test(f)
+}
 
 CONCURRENCY = 3;
 


### PR DESCRIPTION
Fix the issue when files included in modules outside of public or private folders are synced/deployed to the server. 
It will now be possible to have configuration files on that level for example:

```
ls modules/blog
     private
     public
     src
     package.json
```
