### PR TITLE
Use wholePath to read the file but send cleanedUpPath to the backend

### DIFF
--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -69,12 +69,12 @@ const enqueue = filePath => {
   queue.push({ path: filePath }, () => {});
 };
 
-const getBody = (path, processTemplate) => {
+const getBody = (cleanedUpPath, wholePath, processTemplate) => {
   if (processTemplate) {
     logger.Debug('Processing module file as a template');
-    return templates.fillInTemplateValues(path);
+    return templates.fillInTemplateValues(cleanedUpPath);
   } else {
-    return fs.createReadStream(path);
+    return fs.createReadStream(wholePath);
   }
 };
 
@@ -83,7 +83,7 @@ const pushFile = filePath => {
 
   const formData = {
     path: path,
-    marketplace_builder_file_body: getBody(path, path.startsWith('modules'))
+    marketplace_builder_file_body: getBody(path, filePath, path.startsWith('modules'))
   };
 
   return gateway.sync(formData).then(body => {

--- a/marketplace-kit-watch.js
+++ b/marketplace-kit-watch.js
@@ -69,12 +69,12 @@ const enqueue = filePath => {
   queue.push({ path: filePath }, () => {});
 };
 
-const getBody = (cleanedUpPath, wholePath, processTemplate) => {
+const getBody = (path, processTemplate) => {
   if (processTemplate) {
     logger.Debug('Processing module file as a template');
-    return templates.fillInTemplateValues(cleanedUpPath);
+    return templates.fillInTemplateValues(path);
   } else {
-    return fs.createReadStream(wholePath);
+    return fs.createReadStream(path);
   }
 };
 
@@ -83,7 +83,7 @@ const pushFile = filePath => {
 
   const formData = {
     path: path,
-    marketplace_builder_file_body: getBody(path, filePath, path.startsWith('modules'))
+    marketplace_builder_file_body: getBody(filePath, path.startsWith('modules'))
   };
 
   return gateway.sync(formData).then(body => {


### PR DESCRIPTION
For historical reasons, we don't send `marketplace_builder` in the path to backend when syncing but we still do need it when reading in the file