### PR TITLE
Assets manifest: use path instead of mtime; seperate assets per deploy

### DIFF
--- a/lib/deployServiceClient.js
+++ b/lib/deployServiceClient.js
@@ -5,6 +5,7 @@ const io = require('socket.io-client'),
   logger = require('../lib/logger'),
   uploadFile = require('./s3UploadFile'),
   mime = require('mime'),
+  uuidv4 = require('uuid/v4'),
   readdirp = require('readdirp');
 
 const directoriesToIgnore = ['!.git', '!node_modules'];
@@ -20,17 +21,18 @@ const uploadManifest = assetsHash => {
   });
 };
 
-const sendRequestsForPresignedUrls = (socket, assets) => {
+const sendRequestsForPresignedUrls = (socket, assets, remoteAssetsDirectory) => {
   readdirp({
     root: assetsDirectory,
     directoryFilter: directoriesToIgnore
   })
     .on('data', entry => {
-      var fileName = `${assetsDirectory}/${entry.path}`;
+      const fileName = `${remoteAssetsDirectory}/${entry.path}`;
+      const localFileName = `${assetsDirectory}/${entry.path}`;
       assets.push({
         fileName: fileName,
-        contentLength: fs.statSync(fileName)['size'],
-        contentType: mime.getType(fileName)
+        contentLength: fs.statSync(localFileName)['size'],
+        contentType: mime.getType(localFileName)
       });
     })
     .on('end', () => socket.emit('deploy:presign', { urls: assets }));
@@ -76,6 +78,8 @@ const presignUrlsAndUploadFiles = () => {
   return new Promise((resolve, reject) => {
     var assets = [];
     var uploaded = {};
+    const deployUuid = uuidv4();
+    const remoteAssetsDirectory = `deploys/${deployUuid}`;
 
     initializeConnection().then(socket => {
       socket.on('connect_error', err => {
@@ -88,14 +92,18 @@ const presignUrlsAndUploadFiles = () => {
 
       socket.on('connect', () => {
         logger.Debug('[DeployService] Connected requesting presigned S3 urls');
-        sendRequestsForPresignedUrls(socket, assets);
+        sendRequestsForPresignedUrls(socket, assets, remoteAssetsDirectory);
       });
 
       socket.on('deploy:url', data => {
-        uploadFile(data.fileName, data.url)
+        uploadFile(data.fileName.replace(remoteAssetsDirectory, assetsDirectory), data.url)
           .then(() => {
             logger.Print('.');
-            uploaded[data.fileName] = { url: data.accessUrl, mtime: ((new Date()).getTime()/1000|0) };
+            uploaded[data.fileName] = {
+              url: data.accessUrl,
+              path: url.parse(data.accessUrl).pathname,
+              updated_at: ((new Date()).getTime()/1000|0)
+            };
             assets = assets.filter(i => i.fileName !== data.fileName);
             if (assets.length == 0) {
               logger.Print('\n');

--- a/lib/deployServiceClient.js
+++ b/lib/deployServiceClient.js
@@ -5,7 +5,6 @@ const io = require('socket.io-client'),
   logger = require('../lib/logger'),
   uploadFile = require('./s3UploadFile'),
   mime = require('mime'),
-  uuidv4 = require('uuid/v4'),
   readdirp = require('readdirp');
 
 const directoriesToIgnore = ['!.git', '!node_modules'];
@@ -74,12 +73,11 @@ const deployServiceUrl = () => {
   return serviceUrl;
 };
 
-const presignUrlsAndUploadFiles = () => {
+const presignUrlsAndUploadFiles = (instanceId) => {
   return new Promise((resolve, reject) => {
     var assets = [];
     var uploaded = {};
-    const deployUuid = uuidv4();
-    const remoteAssetsDirectory = `deploys/${deployUuid}`;
+    const remoteAssetsDirectory = `instances/${instanceId}/assets`;
 
     initializeConnection().then(socket => {
       socket.on('connect_error', err => {
@@ -121,8 +119,10 @@ const presignUrlsAndUploadFiles = () => {
   });
 };
 
-const deployAssets = () => {
-  return presignUrlsAndUploadFiles();
+const deployAssets = (gateway) => {
+  return gateway.getInstance().then(response => {
+    presignUrlsAndUploadFiles(response.id);
+  });
 };
 
 module.exports = {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -95,6 +95,11 @@ class Gateway {
   push(formData) {
     return this.apiRequest({ method: 'POST', uri: `${this.api_url}/marketplace_releases`, formData });
   }
+
+  getInstance() {
+    return this.apiRequest({ method: 'GET', uri: `${this.api_url}/instance` });
+  }
+
 }
 
 module.exports = Gateway;

--- a/marketplace-kit-deploy.js
+++ b/marketplace-kit-deploy.js
@@ -6,6 +6,7 @@ const program = require('commander'),
   command = require('./lib/command'),
   logger = require('./lib/logger'),
   validate = require('./lib/validators'),
+  Gateway = require('./lib/proxy'),
   deployServiceClient = require('./lib/deployServiceClient'),
   version = require('./package.json').version;
 
@@ -60,7 +61,8 @@ program
     if (process.env.SKIP_DEPLOY_SERVICE) {
       uploadArchive(env, false);
     } else {
-      deployServiceClient.deployAssets().then(
+      const gateway = new Gateway(authData);
+      deployServiceClient.deployAssets(gateway).then(
         () => {
           logger.Success('Assets deployed to S3. Uploading manifest.');
           uploadArchive(env, true);


### PR DESCRIPTION
Related PR: https://github.com/mdyd-dev/desksnearme/pull/8063