### PR TITLE
fix url problem after upload to S3

### DIFF
--- a/lib/data/uploadFiles.js
+++ b/lib/data/uploadFiles.js
@@ -7,7 +7,7 @@ const fs = require('fs'),
   uploadFile = require('./../s3UploadFile');
 
 const filenameForUrl = uri => {
-  return path.basename(url.parse(uri).pathname);
+  return path.basename(uri);
 };
 
 const askForSlot = (tmpFileName, filename) => {
@@ -29,7 +29,7 @@ const askForSlot = (tmpFileName, filename) => {
         if (err || res.statusCode != 200) {
           reject(err || body);
         } else {
-          resolve({ uploadUrl: body.url, accessUrl: body.accessUrl });
+          resolve({ uploadUrl: body.url, accessUrl: url.parse(body.accessUrl).href });
         }
       }
     );


### PR DESCRIPTION
s3 is escaping filenames by itself but is returning unescaped url (containing spaces), hence we do send unescaped file name and escape returned link.