### PR TITLE
When there is an error parsing a file return it's whole content

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -27,7 +27,7 @@ const fillInTemplateValues = (filePath, templateData) => {
       return mustache.render(fileBody, templateData, {}, tags);
     } catch (err) {
       logger.Debug(err);
-      return '';
+      return fileBody;
     }
   } else {
     logger.Debug('Skipping template processing, reading raw file body');

--- a/test/lib/templates.test.js
+++ b/test/lib/templates.test.js
@@ -1,12 +1,13 @@
 const templates = require('./../../lib/templates');
+const fs = require('fs');
 
 process.env.TEMPLATE_VALUES_FILE_PATH = 'test/fixtures/template-values.json';
 
 const fileWithTemplatePath = 'test/fixtures/template.liquid';
 const missformatedTemplatePath = 'test/fixtures/missformatedTemplate.html';
 
-test('returns nothing if it cannont parse the template', () => {
-  expect(templates.fillInTemplateValues(missformatedTemplatePath)).toEqual('');
+test('returns oryginal file body if it runs into error', () => {
+  expect(templates.fillInTemplateValues(missformatedTemplatePath)).toEqual(fs.readFileSync(missformatedTemplatePath, 'utf8'));
 });
 
 test('fills template with values ', () => {


### PR DESCRIPTION
Before this was misbehaving by returning empty string, wipping out
some files by accident. 😳 